### PR TITLE
Add force trial end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,13 @@ You'll also need to make this attribute mass-assignable:
       include Koudoku::Plan
       attr_accessible :interval
     end
+
+## Version 0.0.16
+
+Fixed updating credit card as default. There was issue Accounts that are Past due. CC, cannot be updated.
+
+1. User creates a CF account and makes a valid payment.
+2. After x months' user's CC goes out of date or is declined for another reason.
+3. User loses access to their funnel dashboard.
+4. When user logs back in, they are presented with a choice to choose a new plan.
+5. They enter new CC info and select a plan.

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -7,6 +7,7 @@ module Koudoku::Subscription
     attr_accessor :credit_card_token
     attr_accessor :skip_prorate_plan_changes
     attr_accessor :invoice_immediately
+    attr_accessor :force_trial_end
 
     belongs_to :plan
 
@@ -47,6 +48,8 @@ module Koudoku::Subscription
                   trial_end = trial_end + stripe_plan.trial_period_days.to_i.days
                 end
                 opts = { plan: self.plan.stripe_id, trial_end: trial_end }
+                opts[:trial_end] = "now" if force_trial_end
+
                 opts = subscription_options(opts)
                 customer.update_subscription(opts) if Koudoku.keep_trial_end
               else
@@ -54,6 +57,7 @@ module Koudoku::Subscription
                 opts = {plan: self.plan.stripe_id}
                 opts[:prorate] = false if skip_prorate_plan_changes
                 opts[:billing_cycle_anchor] = "now" if invoice_immediately
+                opts[:trial_end] = "now" if force_trial_end
 
                 opts = subscription_options(opts)
                 customer.update_subscription(opts)

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -2,7 +2,6 @@ module Koudoku::Subscription
   extend ActiveSupport::Concern
 
   included do
-
     # We don't store these one-time use tokens, but this is what Stripe provides
     # client-side after storing the credit card information.
     attr_accessor :credit_card_token

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -126,6 +126,7 @@ module Koudoku::Subscription
               @skip_proccessing_callback = false
 
               # now that we have recorded the stripe_id in our system we can setup the subscription in stripe
+              customer.metadata = subscription_options({})[:metadata]
               customer.plan = plan.stripe_id
               customer.save
             rescue Stripe::CardError => card_error

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -59,7 +59,7 @@ module Koudoku::Subscription
             rescue Stripe::CardError => card_error
               errors[:base] << card_error.message
               card_was_declined
-              return false
+              throw :abort
             end
           # if no plan has been selected.
           else
@@ -126,7 +126,7 @@ module Koudoku::Subscription
             rescue Stripe::CardError => card_error
               errors[:base] << card_error.message
               card_was_declined
-              return false
+              throw :abort
             end
 
             finalize_new_subscription!

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -16,7 +16,7 @@ module Koudoku::Subscription
 
     def processing!
       # if their package level has changed ..
-      if changing_plans? 
+      if changing_plans?
 
         prepare_for_plan_change
 
@@ -146,7 +146,7 @@ module Koudoku::Subscription
         end
 
         finalize_plan_change!
-        
+
       # if they're updating their credit card details.
       elsif self.credit_card_token.present?
         update_default_stripe_card
@@ -166,7 +166,7 @@ module Koudoku::Subscription
       else
         if Koudoku.free_trial?
           "Start Trial"
-        else 
+        else
           "Upgrade"
         end
       end
@@ -221,15 +221,15 @@ module Koudoku::Subscription
   end
 
   def changing_plans?
-    plan_id_changed?
+    will_save_change_to_plan_id?
   end
 
   def downgrading?
-    plan.present? and plan_id_was.present? and plan_id_was > self.plan_id
+    plan.present? and plan_id_before_last_save.present? and plan_id_before_last_save > self.plan_id
   end
 
   def upgrading?
-    (plan_id_was.present? and plan_id_was < plan_id) or plan_id_was.nil?
+    (plan_id_before_last_save.present? and plan_id_before_last_save < plan_id) or plan_id_before_last_save.nil?
   end
 
   # Template methods.
@@ -247,7 +247,7 @@ module Koudoku::Subscription
 
   def prepare_for_cancelation
   end
-  
+
   def prepare_for_card_update
   end
 
@@ -271,14 +271,14 @@ module Koudoku::Subscription
 
   def card_was_declined
   end
-  
+
   # stripe web-hook callbacks.
   def payment_succeeded(amount)
   end
-  
+
   def charge_failed
   end
-  
+
   def charge_disputed
   end
 

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -46,11 +46,14 @@ module Koudoku::Subscription
                 if stripe_plan.trial_period_days
                   trial_end = trial_end + stripe_plan.trial_period_days.to_i.days
                 end
-                customer.update_subscription(:plan => self.plan.stripe_id, trial_end: trial_end) if Koudoku.keep_trial_end
+                opts = { plan: self.plan.stripe_id, trial_end: trial_end }
+                opts = subscription_options(opts)
+                customer.update_subscription(opts) if Koudoku.keep_trial_end
               else
                 # update the package level with stripe.
                 opts = {plan: self.plan.stripe_id}
                 opts[:prorate] = false if skip_prorate_plan_changes
+                opts = subscription_options(opts)
                 customer.update_subscription(opts)
               end
 
@@ -230,6 +233,11 @@ module Koudoku::Subscription
 
   def upgrading?
     (plan_id_before_last_save.present? and plan_id_before_last_save < plan_id) or plan_id_before_last_save.nil?
+  end
+
+  # CF Template methods.
+  def subscription_options(opts = {})
+    opts
   end
 
   # Template methods.

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -72,9 +72,9 @@ module Koudoku::Subscription
             # delete the subscription. - at_period_end if prorate == false
             begin
               customer.cancel_subscription({:at_period_end => (!Koudoku.prorate).to_s })
-            rescue Exception => e
-              errors[:base] << e.message
-              return false
+            rescue => e
+              logger.info "Error Canceling Stripe Subscription: #{e.to_s}"
+              # assume already canceled by support
             end
 
             finalize_cancelation!

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -7,6 +7,7 @@ module Koudoku::Subscription
     # client-side after storing the credit card information.
     attr_accessor :credit_card_token
     attr_accessor :skip_prorate_plan_changes
+    attr_accessor :invoice_immediately
 
     belongs_to :plan
 
@@ -53,6 +54,7 @@ module Koudoku::Subscription
                 # update the package level with stripe.
                 opts = {plan: self.plan.stripe_id}
                 opts[:prorate] = false if skip_prorate_plan_changes
+                opts[:billing_cycle_anchor] = "now" if invoice_immediately
                 opts = subscription_options(opts)
                 customer.update_subscription(opts)
               end

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -46,14 +46,11 @@ module Koudoku::Subscription
                 if stripe_plan.trial_period_days
                   trial_end = trial_end + stripe_plan.trial_period_days.to_i.days
                 end
-                opts = { plan: self.plan.stripe_id, trial_end: trial_end }
-                opts = subscription_options(opts)
-                customer.update_subscription(opts) if Koudoku.keep_trial_end
+                customer.update_subscription(:plan => self.plan.stripe_id, trial_end: trial_end) if Koudoku.keep_trial_end
               else
                 # update the package level with stripe.
                 opts = {plan: self.plan.stripe_id}
                 opts[:prorate] = false if skip_prorate_plan_changes
-                opts = subscription_options(opts)
                 customer.update_subscription(opts)
               end
 
@@ -233,11 +230,6 @@ module Koudoku::Subscription
 
   def upgrading?
     (plan_id_before_last_save.present? and plan_id_before_last_save < plan_id) or plan_id_before_last_save.nil?
-  end
-
-  # CF Template methods.
-  def subscription_options(opts = {})
-    opts
   end
 
   # Template methods.

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -6,7 +6,8 @@ module Koudoku::Subscription
     # We don't store these one-time use tokens, but this is what Stripe provides
     # client-side after storing the credit card information.
     attr_accessor :credit_card_token
-    
+    attr_accessor :skip_prorate_plan_changes
+
     belongs_to :plan
 
     # update details.
@@ -47,7 +48,9 @@ module Koudoku::Subscription
               customer.update_subscription(:plan => self.plan.stripe_id, trial_end: trial_end) if Koudoku.keep_trial_end
             else
               # update the package level with stripe.
-              customer.update_subscription(:plan => self.plan.stripe_id)
+              opts = {plan: self.plan.stripe_id}
+              opts[:prorate] = false if skip_prorate_plan_changes
+              customer.update_subscription(opts)
             end
 
             finalize_downgrade! if downgrading?

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -194,6 +194,10 @@ module Koudoku::Subscription
     customer = Stripe::Customer.retrieve(self.stripe_id)
     source = customer.sources.create(source: credit_card_token)
     customer.default_source = source.id
+    # Undo payment_method set by the payment_methods API as this will override the default_source
+    if !customer.invoice_settings.default_payment_method.nil?
+      customer.invoice_settings.default_payment_method = nil
+    end
     customer.save
 
     # update the last four based on this new card.

--- a/app/concerns/koudoku/subscription.rb
+++ b/app/concerns/koudoku/subscription.rb
@@ -55,6 +55,7 @@ module Koudoku::Subscription
                 opts = {plan: self.plan.stripe_id}
                 opts[:prorate] = false if skip_prorate_plan_changes
                 opts[:billing_cycle_anchor] = "now" if invoice_immediately
+
                 opts = subscription_options(opts)
                 customer.update_subscription(opts)
               end

--- a/lib/koudoku/version.rb
+++ b/lib/koudoku/version.rb
@@ -1,3 +1,3 @@
 module Koudoku
-  VERSION = "0.0.15"
+  VERSION = "0.0.16"
 end


### PR DESCRIPTION
Add support to force a subscriptions trial to end. 

Setting `force_trial_end` on a subscription will trigger this concern to update stripe and tell it to end trial now


https://stripe.com/docs/api/subscriptions/update#update_subscription-trial_end